### PR TITLE
changed input_type to holding for 21232 and 21263

### DIFF
--- a/modbus_wallbox.yaml
+++ b/modbus_wallbox.yaml
@@ -40,7 +40,7 @@ modbus:
         unique_id: wb1_working_mode
         slave: !secret wallbox_modbus_slave
         address: 21262 # reg 21263
-        input_type: input
+        input_type: holding
         data_type: uint16
         scan_interval: 600
 
@@ -210,7 +210,7 @@ modbus:
         unique_id: wb1_mile_per_kwh
         slave: !secret wallbox_modbus_slave
         address: 21231 # reg 21232
-        input_type: input
+        input_type: holding
         data_type: uint16
         scan_interval: 10
 


### PR DESCRIPTION
I have added your yaml to my HA and it has thrown errors for "Mileage per kWh" and "Working mode". I have tested a bit with modbus-cli and found out, that these registers are not input (as described in the Sungrow Wallbox documentation) but of type holding. With the changed input_type I get values in my HA.

Offtopic: I had to use the LAN port of the dongle, the ModBus LAN port ist not working. Additionally I hat to use slave id 3 and not 248. You can lookup the ids in the webinterface of the dongle.