### PR TITLE
Added unit_of_measurement, precision and scale to wb1_mile_per_kwh

### DIFF
--- a/modbus_wallbox.yaml
+++ b/modbus_wallbox.yaml
@@ -212,6 +212,9 @@ modbus:
         address: 21231 # reg 21232
         input_type: holding
         data_type: uint16
+        unit_of_measurement: km/kWh
+        precision: 1
+        scale: 0.1
         scan_interval: 10
 
       #####################


### PR DESCRIPTION
Added unit_of_measurement, precision and scale to wb1_mile_per_kwh so the value (default: 50) is shown as 5.0 km/kWh as described in the Sungrow documentation.