### PR TITLE
Fixed registers and new charging duration template

### DIFF
--- a/modbus_wallbox.yaml
+++ b/modbus_wallbox.yaml
@@ -169,11 +169,10 @@ modbus:
         address: 21309 # reg 21310
         input_type: input
         data_type: uint32
-        unit_of_measurement: kWh
+        unit_of_measurement: Wh
         device_class: Energy
         state_class: total_increasing
-        precision: 3
-        scale: 0.001
+        scale: 1
         swap: word
         scan_interval: 60 
 

--- a/modbus_wallbox.yaml
+++ b/modbus_wallbox.yaml
@@ -237,7 +237,7 @@ modbus:
         data_type: uint16
         scan_interval: 10
 
-       - name: Mileage per kWh
+      - name: Mileage per kWh
         unique_id: wb1_mile_per_kwh
         slave: !secret wallbox_modbus_slave
         address: 21231 # reg 21232
@@ -248,7 +248,7 @@ modbus:
         scale: 0.1
         scan_interval: 10
 
-       - name: Working mode
+      - name: Working mode
         unique_id: wb1_working_mode
         slave: !secret wallbox_modbus_slave
         address: 21262 # reg 21263

--- a/modbus_wallbox.yaml
+++ b/modbus_wallbox.yaml
@@ -269,6 +269,11 @@ template:
         unique_id: wb1_charging_end_time
         state: >
           {{ as_local(as_datetime(states.sensor.charging_end_time_raw.state)).isoformat() }}
+
+      - name: Charging duration
+        unique_id: wb1_charging_duration
+        state: >
+          {{ as_datetime(states.sensor.charging_end_time_raw.state) - as_datetime(states.sensor.charging_start_time_raw.state) }}
   
       - name: Wallbox device type
         unique_id: wb1_device_type

--- a/modbus_wallbox.yaml
+++ b/modbus_wallbox.yaml
@@ -61,7 +61,7 @@ modbus:
         slave: !secret wallbox_modbus_slave
         address: 21272 # reg 21273
         input_type: input
-        data_type: uint32
+        data_type: uint16
         precision: 1
         unit_of_measurement: W
         device_class: Power
@@ -78,6 +78,7 @@ modbus:
         unit_of_measurement: Wh
         device_class: Energy
         scale: 1
+        swap: word
         scan_interval: 600
 
       - name: Phase A charging voltage
@@ -168,10 +169,12 @@ modbus:
         address: 21309 # reg 21310
         input_type: input
         data_type: uint32
-        unit_of_measurement: Wh
+        unit_of_measurement: kWh
         device_class: Energy
         state_class: total_increasing
-        scale: 1
+        precision: 3
+        scale: 0.001
+        swap: word
         scan_interval: 60 
 
       - name: Charging status Raw

--- a/modbus_wallbox.yaml
+++ b/modbus_wallbox.yaml
@@ -36,14 +36,6 @@ modbus:
         device_class: Voltage
         scan_interval: 600
 
-      - name: Working mode
-        unique_id: wb1_working_mode
-        slave: !secret wallbox_modbus_slave
-        address: 21262 # reg 21263
-        input_type: holding
-        data_type: uint16
-        scan_interval: 600
-
       - name: Phase switching status Raw
         unique_id: wb1_phase_switching_status_raw
         slave: !secret wallbox_modbus_slave
@@ -208,17 +200,6 @@ modbus:
         swap: word
         scan_interval: 10
 
-      - name: Mileage per kWh
-        unique_id: wb1_mile_per_kwh
-        slave: !secret wallbox_modbus_slave
-        address: 21231 # reg 21232
-        input_type: holding
-        data_type: uint16
-        unit_of_measurement: km/kWh
-        precision: 1
-        scale: 0.1
-        scan_interval: 10
-
       #####################
       # holding registers
       #####################
@@ -255,6 +236,25 @@ modbus:
         input_type: holding
         data_type: uint16
         scan_interval: 10
+
+       - name: Mileage per kWh
+        unique_id: wb1_mile_per_kwh
+        slave: !secret wallbox_modbus_slave
+        address: 21231 # reg 21232
+        input_type: holding
+        data_type: uint16
+        unit_of_measurement: km/kWh
+        precision: 1
+        scale: 0.1
+        scan_interval: 10
+
+       - name: Working mode
+        unique_id: wb1_working_mode
+        slave: !secret wallbox_modbus_slave
+        address: 21262 # reg 21263
+        input_type: holding
+        data_type: uint16
+        scan_interval: 600
 
 template:
   - sensor:

--- a/modbus_wallbox.yaml
+++ b/modbus_wallbox.yaml
@@ -1,7 +1,7 @@
 # Home Assistant Sungrow wallbox integration
 # https://github.com/Louisbertelsmann/Sungrow-Wallbox-Modbus-HomeAssistant
 # by Louis Bertelsmann
-# last update: 2023-12-13
+# last update: 2024-02-09
 
 modbus:
   - name: SungrowACx

--- a/modbus_wallbox.yaml
+++ b/modbus_wallbox.yaml
@@ -261,12 +261,12 @@ template:
       - name: Charging start time
         unique_id: wb1_charging_start_time
         state: >
-          {{ as_datetime(states.sensor.charging_start_time_raw.state) }}
+          {{ as_local(as_datetime(states.sensor.charging_start_time_raw.state)).isoformat() }}
 
       - name: Charging end time
         unique_id: wb1_charging_end_time
         state: >
-          {{ as_datetime(states.sensor.charging_end_time_raw.state) }}
+          {{ as_local(as_datetime(states.sensor.charging_end_time_raw.state)).isoformat() }}
   
       - name: Wallbox device type
         unique_id: wb1_device_type


### PR DESCRIPTION
I have added option swap for some more registers, fixed one data_type with was wrong in the documentation and added a template for last charging duration.
![image](https://github.com/Louisbertelsmann/Sungrow-Wallbox-Modbus-HomeAssistant/assets/153714968/9c4545ae-9f7f-4d74-977e-cfb5b9b6c2e0)
![image](https://github.com/Louisbertelsmann/Sungrow-Wallbox-Modbus-HomeAssistant/assets/153714968/bb44b826-f4f4-47de-b2b2-1d4babd27e3e)
