### PR TITLE
Fast update only when charging / documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@ An addition to the Sungrow Inverter Repository from mkaiser.
 # Contents
 - [1. Overview](#1-overview)
 - [2. Documentation](#2-documentation)
-    - [Installation/ Configuration](https://github.com/Louisbertelsmann/Sungrow-Wallbox-Modbus-HomeAssistant/wiki/How-to-install)
-    - [Dashboard Setup](https://github.com/Louisbertelsmann/Sungrow-Wallbox-Modbus-HomeAssistant/wiki/Dashboard-Setup)
-    - [Usage Instructions](https://github.com/Louisbertelsmann/Sungrow-Wallbox-Modbus-HomeAssistant/wiki/Usage-instructions)
+    - [Installation/ Configuration](#21-installation)
+    - [Dashboard Setup](#22-dashboard-setup)
+    - [Usage Instructions](#23-usage-instructions)
 - [3. Support](#3-support)
 - [4. Visual impressions](#4-visual-impressions)
 
@@ -19,10 +19,35 @@ Please ensure the connection to either the inverter or other connection to a net
 
 The documentation covers following topics:
 
-[Installation/ Configuration](https://github.com/Louisbertelsmann/Sungrow-Wallbox-Modbus-HomeAssistant/wiki/How-to-install)
+### 2.1. Installation
+#### 2.1.1. Lookup slave id of wallbox
+Open the WiNet-S web interface /LAN or WLAN) and lookup the slave id of your wallbox (here 3):
+![image](https://github.com/SunnyCrockett/Sungrow-Wallbox-Modbus-HomeAssistant/assets/153714968/fe607ab4-1f6f-4ffc-b2cd-eac9775efe32)
 
+#### 2.1.2. secrets.yaml
+Add the following lines to your secrets.yaml and set your values:
+```
+wallbox_modbus_host_ip: expressif  # TODO update with the IP of your inverters WiNet-S dongle (not ModBus LAN port). No default. Check your router.
+wallbox_modbus_port: 502 # TODO update with the Modbus port of your inverter WiNet-S dongle. Default is '502'
+wallbox_modbus_slave: 3 #TODO update with the slave address of your wallbox. Default is '3'
+```
+#### 2.1.3. Home Assistant configuration
+
+The file modbus_wallbox.yaml contains the Modbus register maps, template sensors and automations. Copy the file to a subfolder named "integrations" (maybe create it first), which is located at the same level as your "configurations.yaml".
+
+Include "modbus_wallbox.yaml" by adding the follwing lines to your "configuration.yaml":
+```
+homeassistant:
+  packages: !include_dir_named integrations
+```
+Do not forget to check your configuration (Developer Tools --> hit "check configuration" and restart: it won't work without a restart!)
+
+After the restart, some new sensors should be available. E.g., check for "Wallbox device type"
+
+### 2.2. Dashboard setup
 [Dashboard Setup](https://github.com/Louisbertelsmann/Sungrow-Wallbox-Modbus-HomeAssistant/wiki/Dashboard-Setup)
 
+### 2.3. Usage instructions
 [Usage Instructions](https://github.com/Louisbertelsmann/Sungrow-Wallbox-Modbus-HomeAssistant/wiki/Usage-instructions)
 
 ## 3. Support
@@ -32,3 +57,9 @@ If you any kind of assistance, you have two options:
 - Use the [github discussion](../../discussions) 
 
 - Only if code-related (bugs / contributions): Open an  [github issue](../../issue) or isse a pullrequest
+
+## 4. Visual impressions
+![infos](https://github.com/SunnyCrockett/Sungrow-Wallbox-Modbus-HomeAssistant/assets/153714968/df966f51-7655-40e3-bc35-ef90e99655e4)
+![last](https://github.com/SunnyCrockett/Sungrow-Wallbox-Modbus-HomeAssistant/assets/153714968/645b4521-c40f-420e-a364-19488f2b672f)
+![current](https://github.com/SunnyCrockett/Sungrow-Wallbox-Modbus-HomeAssistant/assets/153714968/1bf2b6fc-6277-4886-beb2-96e014d72531)
+![settings](https://github.com/SunnyCrockett/Sungrow-Wallbox-Modbus-HomeAssistant/assets/153714968/86569e0f-428e-4da5-9035-13cc9f2628f5)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-An addition to the Sungrow Inverter Repository from mkaiser.
+> An addition to the [Sungrow Inverter Repository from mkaiser](https://github.com/mkaiser/Sungrow-SHx-Inverter-Modbus-Home-Assistant).
 
 # Contents
 - [1. Overview](#1-overview)
@@ -15,42 +15,37 @@ This integration lets you gather sensor data and control several parameters of (
 
 Please ensure the connection to either the inverter or other connection to a network is stable, else you might get false readings.
 
-## 2. Documentation
+# 2. Documentation
 
 The documentation covers following topics:
 
-### 2.1. Installation
-#### 2.1.1. Lookup slave id of wallbox
+## 2.1. Installation
+### 2.1.1. Lookup slave id of wallbox
 Open the WiNet-S web interface /LAN or WLAN) and lookup the slave id of your wallbox (here 3):
 ![image](https://github.com/SunnyCrockett/Sungrow-Wallbox-Modbus-HomeAssistant/assets/153714968/fe607ab4-1f6f-4ffc-b2cd-eac9775efe32)
 
-#### 2.1.2. secrets.yaml
+### 2.1.2. secrets.yaml
 Add the following lines to your secrets.yaml and set your values:
 ```
 wallbox_modbus_host_ip: expressif  # TODO update with the IP of your inverters WiNet-S dongle (not ModBus LAN port). No default. Check your router.
 wallbox_modbus_port: 502 # TODO update with the Modbus port of your inverter WiNet-S dongle. Default is '502'
 wallbox_modbus_slave: 3 #TODO update with the slave address of your wallbox. Default is '3'
 ```
-#### 2.1.3. Home Assistant configuration
+### 2.1.3. Home Assistant configuration
 
-The file modbus_wallbox.yaml contains the Modbus register maps, template sensors and automations. Copy the file to a subfolder named "integrations" (maybe create it first), which is located at the same level as your "configurations.yaml".
-
-Include "modbus_wallbox.yaml" by adding the follwing lines to your "configuration.yaml":
-```
-homeassistant:
-  packages: !include_dir_named integrations
-```
+The file modbus_wallbox.yaml contains the Modbus register maps, template sensors and automations. Copy the file to the subfolder named "integrations", which is located at the same level as your "configurations.yaml".
 Do not forget to check your configuration (Developer Tools --> hit "check configuration" and restart: it won't work without a restart!)
 
 After the restart, some new sensors should be available. E.g., check for "Wallbox device type"
 
-### 2.2. Dashboard setup
+## 2.2. Dashboard setup
 [Dashboard Setup](https://github.com/Louisbertelsmann/Sungrow-Wallbox-Modbus-HomeAssistant/wiki/Dashboard-Setup)
 
-### 2.3. Usage instructions
+## 2.3. Usage instructions
 [Usage Instructions](https://github.com/Louisbertelsmann/Sungrow-Wallbox-Modbus-HomeAssistant/wiki/Usage-instructions)
 
-## 3. Support
+# 3. Support
+Please consider using a ModBus proxy if you have problems with reading the registers. ModBus needs some time especially in combination with the WiNet-S dongle. For me its working a connection_time of 0.5. 
 
 If you any kind of assistance, you have two options:
 
@@ -58,7 +53,7 @@ If you any kind of assistance, you have two options:
 
 - Only if code-related (bugs / contributions): Open an  [github issue](../../issue) or isse a pullrequest
 
-## 4. Visual impressions
+# 4. Visual impressions
 ![infos](https://github.com/SunnyCrockett/Sungrow-Wallbox-Modbus-HomeAssistant/assets/153714968/df966f51-7655-40e3-bc35-ef90e99655e4)
 ![last](https://github.com/SunnyCrockett/Sungrow-Wallbox-Modbus-HomeAssistant/assets/153714968/645b4521-c40f-420e-a364-19488f2b672f)
 ![current](https://github.com/SunnyCrockett/Sungrow-Wallbox-Modbus-HomeAssistant/assets/153714968/1bf2b6fc-6277-4886-beb2-96e014d72531)

--- a/modbus_wallbox.yaml
+++ b/modbus_wallbox.yaml
@@ -90,7 +90,7 @@ modbus:
         unit_of_measurement: V
         device_class: Voltage
         scale: 0.1
-        scan_interval: 10
+        scan_interval: 600
 
       - name: Phase A charging current
         unique_id: wb1_phase_a_charging_current
@@ -102,7 +102,7 @@ modbus:
         device_class: power
         state_class: measurement
         scale: 0.1
-        scan_interval: 10
+        scan_interval: 600
 
       - name: Phase B charging voltage
         unique_id: wb1_phase_b_charging_voltage
@@ -114,7 +114,7 @@ modbus:
         device_class: Voltage
         state_class: measurement
         scale: 0.1
-        scan_interval: 10
+        scan_interval: 600
 
       - name: Phase B charging current
         unique_id: wb1_phase_b_charging_current
@@ -126,7 +126,7 @@ modbus:
         device_class: Current
         state_class: measurement
         scale: 0.1
-        scan_interval: 10
+        scan_interval: 600
 
       - name: Phase C charging voltage
         unique_id: wb1_phase_c_charging_voltage
@@ -138,7 +138,7 @@ modbus:
         device_class: Voltage
         state_class: measurement
         scale: 0.1
-        scan_interval: 10
+        scan_interval: 600
 
       - name: Phase C charging current
         unique_id: wb1_phase_c_charging_current
@@ -150,7 +150,7 @@ modbus:
         device_class: Current
         state_class: measurement
         scale: 0.1
-        scan_interval: 10
+        scan_interval: 600
 
       - name: Charging power
         unique_id: wb1_charging_power
@@ -162,7 +162,7 @@ modbus:
         device_class: power
         state_class: measurement
         swap: word
-        scan_interval: 10
+        scan_interval: 600
 
       - name: Charging energy
         unique_id: wb1_charging_energy
@@ -175,7 +175,7 @@ modbus:
         state_class: total_increasing
         scale: 1
         swap: word
-        scan_interval: 10 
+        scan_interval: 600 
 
       - name: Charging status Raw
         unique_id: wb1_charging_status
@@ -192,7 +192,7 @@ modbus:
         input_type: input
         data_type: uint32
         swap: word
-        scan_interval: 10
+        scan_interval: 600
       
       - name: Charging end time Raw
         unique_id: wb1_charging_end_time_raw
@@ -201,7 +201,7 @@ modbus:
         input_type: input
         data_type: uint32
         swap: word
-        scan_interval: 10
+        scan_interval: 600
 
       #####################
       # holding registers
@@ -214,7 +214,7 @@ modbus:
         input_type: holding
         data_type: uint16
         scale: 0.1
-        scan_interval: 10
+        scan_interval: 600
 
       - name: Single phase/Three phase switching
         unique_id: wb1_phase_switching
@@ -222,7 +222,7 @@ modbus:
         address: 21203 # reg 21204
         input_type: holding
         data_type: uint16
-        scan_interval: 10
+        scan_interval: 60
 
       - name: Charger enable
         unique_id: wb1_charger_enable
@@ -230,7 +230,7 @@ modbus:
         address: 21210 # reg 21211
         input_type: holding
         data_type: uint16
-        scan_interval: 10
+        scan_interval: 60
 
       - name: Remote control
         unique_id: wb1_remote_control
@@ -238,7 +238,7 @@ modbus:
         address: 21211 # reg 21212
         input_type: holding
         data_type: uint16
-        scan_interval: 10
+        scan_interval: 60
 
       - name: Mileage per kWh
         unique_id: wb1_mile_per_kwh
@@ -249,7 +249,7 @@ modbus:
         unit_of_measurement: km/kWh
         precision: 1
         scale: 0.1
-        scan_interval: 10
+        scan_interval: 60
 
       - name: Working mode
         unique_id: wb1_working_mode
@@ -489,4 +489,46 @@ automation:
             {% elif is_state('input_select.set_wb_remote_control', "Stop charging") %} 
               {{stop_charging}}
             {% endif %}
+    mode: single
+
+  - id: "automation_fast_update_while_charging"
+    alias: automation_fast_update_while_charging
+    description: Update relevant entities for charging every 10sec and not just every hour
+    trigger:
+      - platform: state
+        entity_id:
+          - sensor.charging_status_raw
+        to: "3"
+    condition: []
+    action:
+      - service: homeassistant.update_entity
+        data: {}
+        target:
+          entity_id: sensor.charging_start_time_raw
+      - repeat:
+          sequence:
+            - service: homeassistant.update_entity
+              data: {}
+              target:
+                entity_id:
+                  - sensor.charging_power
+                  - sensor.phase_a_charging_current
+                  - sensor.phase_a_charging_voltage
+                  - sensor.phase_b_charging_current
+                  - sensor.phase_b_charging_voltage
+                  - sensor.phase_c_charging_current
+                  - sensor.phase_c_charging_voltage
+                  - sensor.output_current_setting
+                  - sensor.charging_energy
+                  - sensor.charging_end_time_raw
+                  - sensor.total_energy
+            - delay:
+                hours: 0
+                minutes: 0
+                seconds: 10
+                milliseconds: 0
+          while:
+            - condition: state
+              entity_id: sensor.charging_status_raw
+              state: "3"
     mode: single


### PR DESCRIPTION
I changed the scan_interval for all registers which are only interesting while charing. In addition there is an automation which is triggered by the charge status. When charging, the registers are updated every 10sec.
I added some documentation incl. pictures how to find slave id and visual impressions from my HA dashboard.