### PR TITLE
removed as_local from wb1_charging_start/end_time

### DIFF
--- a/modbus_wallbox.yaml
+++ b/modbus_wallbox.yaml
@@ -264,12 +264,12 @@ template:
       - name: Charging start time
         unique_id: wb1_charging_start_time
         state: >
-          {{ as_local(as_datetime(states.sensor.charging_start_time_raw.state)).strftime("%d.%m.%Y %H:%M") }}
+          {{ as_datetime(states.sensor.charging_start_time_raw.state).strftime("%d.%m.%Y %H:%M") }}
 
       - name: Charging end time
         unique_id: wb1_charging_end_time
         state: >
-          {{ as_local(as_datetime(states.sensor.charging_end_time_raw.state)).strftime("%d.%m.%Y %H:%M") }}
+          {{ as_datetime(states.sensor.charging_end_time_raw.state).strftime("%d.%m.%Y %H:%M") }}
 
       - name: Charging duration
         unique_id: wb1_charging_duration


### PR DESCRIPTION
After I updated my wallbox, I had the same time issue like btota. So I removed the as_local from the config to display the values correctly